### PR TITLE
Adds an environment variable to control whether to make uploaded files world readable or not

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ MAINTAINER Przemyslaw Ozgo przemek@m12.io
 ENV FTP_USER=admin \
     FTP_PASS=random \
     LOG_STDOUT=false \
-    ANONYMOUS_ACCESS=false
+    ANONYMOUS_ACCESS=false \
+    UPLOADED_FILES_WORLD_READABLE=false
 
 RUN \
   rpm --rebuilddb && yum clean all && \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ This vsftpd docker image is based on official CentOS 7 image and comes with foll
 |Accepted values:|`true` or `false`|
 |Description:|Grants access to user `anonymous` need to have access to files in `/var/ftp/pub` directory.|
 
+|UPLOADED_FILES_WORLD_READABLE||
+|---|---|
+|Default:|`UPLOADED_FILES_WORLD_READABLE=false`|
+|Accepted values:|`true` or `false`|
+|Description:|Changes the permmissions of uploaded files to `rw- r-- r--`. This makes files readable by other users.|
+
 ### Basic usage
 
     docker run \

--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -37,6 +37,12 @@ if [ "${ANONYMOUS_ACCESS}" = "true" ]; then
   log "Enabled access for anonymous user."
 fi
 
+# Uploaded files world readable settings
+if [ "${UPLOADED_FILES_WORLD_READABLE}" = "true" ]; then
+  sed -i "s|local_umask=077|local_umask=022|g" /etc/vsftpd/vsftpd.conf
+  log "Uploaded files will become world readable."
+fi
+
 # Create home dir and update vsftpd user db:
 mkdir -p "/home/vsftpd/${FTP_USER}"
 log "Created home directory for user: ${FTP_USER}"

--- a/container-files/etc/vsftpd/vsftpd.conf
+++ b/container-files/etc/vsftpd/vsftpd.conf
@@ -51,3 +51,6 @@ xferlog_file=/var/log/vsftpd/vsftpd.log
 port_enable=YES
 connect_from_port_20=YES
 ftp_data_port=20
+
+## make uploaded files world readable
+local_umask=022

--- a/container-files/etc/vsftpd/vsftpd.conf
+++ b/container-files/etc/vsftpd/vsftpd.conf
@@ -52,5 +52,7 @@ port_enable=YES
 connect_from_port_20=YES
 ftp_data_port=20
 
-## make uploaded files world readable
-local_umask=022
+## control umask of uploaded files
+# * 077 means that uploaded files get rw- --- ---
+# * 022 means that uploaded files get rw- r-- r--
+local_umask=077


### PR DESCRIPTION
This PR results from the discussion in #4 

It adds the `UPLOADED_FILES_WORLD_READABLE` environment variable. This controls the value of vsftpd's `local_umask` configuration parameter. The default value of `false` makes vsftpd apply the default (and safer) umask of `077`, which translates to file permissions being `rw- --- ---`. This means that by default uploaded files are only accessible by their uploading user.

Setting `-e UPLOADED_FILES_WORLD_READABLE=true` means that the corresponding vsftpd configuration will become `local_umask=022`. This translates into file permissions of `rw- r-- r--`, thus making uploaded files readable by anyone.