### PR TITLE
Add PASV_ADDRESS as another configurable option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ENV FTP_USER=admin \
     FTP_PASS=random \
     LOG_STDOUT=false \
     ANONYMOUS_ACCESS=false \
-    UPLOADED_FILES_WORLD_READABLE=false
+    UPLOADED_FILES_WORLD_READABLE=false \
+    CUSTOM_PASSIVE_ADDRESS=false
 
 RUN \
   rpm --rebuilddb && yum clean all && \

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ This vsftpd docker image is based on official CentOS 7 image and comes with foll
 |Accepted values:|`true` or `false`|
 |Description:|Changes the permmissions of uploaded files to `rw- r-- r--`. This makes files readable by other users.|
 
+|CUSTOM_PASSIVE_ADDRESS||
+|---|---|
+|Default:|`CUSTOM_PASSIVE_ADDRESS=false`|
+|Accepted values:|`ip address` or `false`|
+|Description:|Passive Address that gets advertised by vsftpd when responding to PASV command. This is useul when running behind a proxy, or with docker swarm.|
+
+
 ### Basic usage
 
     docker run \

--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -43,6 +43,14 @@ if [ "${UPLOADED_FILES_WORLD_READABLE}" = "true" ]; then
   log "Uploaded files will become world readable."
 fi
 
+# WIP-----------------------------------------
+# Custom passive address settings
+if [ "${CUSTOM_PASSIVE_ADDRESS}" = "true" ]; then
+  sed -i "s|local_umask=077|local_umask=022|g" /etc/vsftpd/vsftpd.conf
+  log "Uploaded files will become world readable."
+fi
+
+
 # Create home dir and update vsftpd user db:
 mkdir -p "/home/vsftpd/${FTP_USER}"
 log "Created home directory for user: ${FTP_USER}"

--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -43,11 +43,10 @@ if [ "${UPLOADED_FILES_WORLD_READABLE}" = "true" ]; then
   log "Uploaded files will become world readable."
 fi
 
-# WIP-----------------------------------------
 # Custom passive address settings
-if [ "${CUSTOM_PASSIVE_ADDRESS}" = "true" ]; then
-  sed -i "s|local_umask=077|local_umask=022|g" /etc/vsftpd/vsftpd.conf
-  log "Uploaded files will become world readable."
+if [ "${CUSTOM_PASSIVE_ADDRESS}" != "false" ]; then
+  sed -i "s|pasv_address=|pasv_address=${CUSTOM_PASSIVE_ADDRESS}|g" /etc/vsftpd/vsftpd.conf
+  log "Passive mode will advertise address ${CUSTOM_PASSIVE_ADDRESS}"
 fi
 
 

--- a/container-files/etc/vsftpd/vsftpd.conf
+++ b/container-files/etc/vsftpd/vsftpd.conf
@@ -36,6 +36,9 @@ allow_writeable_chroot=YES
 ## Hide ids from user
 hide_ids=YES
 
+## Passive Address that gets advertised by vsftpd when responding to PASV command
+pasv_address=
+
 ## Enable passive mode
 pasv_enable=YES
 


### PR DESCRIPTION
This PR relates to issue #6 

It adds the `CUSTOM_PASSIVE_ADDRESS` variable. This makes it possible to supply an ip address to be advertized by vsftpd when using passive mode. It uses vsftpd's `PASV_ADDRESS` configuration option.

The option is `false` by default, meaning that this is a backwards compatible change.