### PR TITLE
Fix Environmental Variables title syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This vsftpd docker image is based on official CentOS 7 image and comes with foll
   * Logging to a file or STDOUT
   * Anonymous account access (defined by user on docker run `true/false`)
 
-### Environmental Variables
+### Environmental Variables
 
 |FTP_USER||
 |---|---|


### PR DESCRIPTION
# Changed log

- Fix the `Environmental Variables` markdown syntax title.